### PR TITLE
Upgrade JUnit and Gson to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.2</version>
+			<version>2.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -23,8 +23,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Upgraded the following dependencies to their latest versions:
- JUnit: 4.12 -> 4.13.2
- Gson: 2.8.2 -> 2.10.1

Also, updated the Java source and target version from 1.7 to 1.8 to support the new library versions.